### PR TITLE
Update reach terminology and implement ranges

### DIFF
--- a/bot/states.py
+++ b/bot/states.py
@@ -40,7 +40,11 @@ class SellerStates(StatesGroup):
     # Статистика (загрузка)
     waiting_for_statistics = State()  # Загрузка статистики
     waiting_for_subscribers_count = State()  # Количество подписчиков
-    waiting_for_avg_views = State()  # Средние просмотры
+    waiting_for_avg_views = State()  # Средние охваты (устаревшее, для совместимости)
+    waiting_for_stories_reach_min = State()  # Минимальный охват сторис
+    waiting_for_stories_reach_max = State()  # Максимальный охват сторис
+    waiting_for_reels_reach_min = State()  # Минимальный охват рилс
+    waiting_for_reels_reach_max = State()  # Максимальный охват рилс
     waiting_for_avg_likes = State()  # Средние лайки
     waiting_for_engagement_rate = State()  # Процент вовлеченности
     

--- a/database/database.py
+++ b/database/database.py
@@ -85,6 +85,14 @@ async def init_db():
                 avg_views INTEGER,
                 avg_likes INTEGER,
                 engagement_rate REAL,
+                
+                -- Охваты сторис (вилка)
+                stories_reach_min INTEGER,
+                stories_reach_max INTEGER,
+                
+                -- Охваты рилс (вилка)
+                reels_reach_min INTEGER,
+                reels_reach_max INTEGER,
 
                 -- Скриншоты/фотографии статистики (JSON массив путей или URL)
                 stats_images TEXT,
@@ -322,6 +330,23 @@ async def init_db():
             if 'engagement_rate' not in columns:
                 await db.execute("ALTER TABLE bloggers ADD COLUMN engagement_rate REAL")
                 logger.info("Added engagement_rate column to bloggers table")
+            
+            # Добавляем новые колонки для охватов
+            if 'stories_reach_min' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN stories_reach_min INTEGER")
+                logger.info("Added stories_reach_min column to bloggers table")
+            
+            if 'stories_reach_max' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN stories_reach_max INTEGER")
+                logger.info("Added stories_reach_max column to bloggers table")
+            
+            if 'reels_reach_min' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN reels_reach_min INTEGER")
+                logger.info("Added reels_reach_min column to bloggers table")
+            
+            if 'reels_reach_max' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN reels_reach_max INTEGER")
+                logger.info("Added reels_reach_max column to bloggers table")
 
             if 'stats_images' not in columns:
                 await db.execute("ALTER TABLE bloggers ADD COLUMN stats_images TEXT")
@@ -576,10 +601,11 @@ async def create_blogger(
                 price_stories, price_post, price_video,
                 has_reviews, is_registered_rkn, official_payment_possible,
                 subscribers_count, avg_views, avg_likes, engagement_rate,
+                stories_reach_min, stories_reach_max, reels_reach_min, reels_reach_max,
                 stats_images,
                 description
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
             (
                 seller_id,
@@ -603,6 +629,10 @@ async def create_blogger(
                 kwargs.get("avg_views"),
                 kwargs.get("avg_likes"),
                 kwargs.get("engagement_rate"),
+                kwargs.get("stories_reach_min"),
+                kwargs.get("stories_reach_max"),
+                kwargs.get("reels_reach_min"),
+                kwargs.get("reels_reach_max"),
                 json.dumps(kwargs.get("stats_images", [])),
                 kwargs.get("description"),
             ),
@@ -669,6 +699,10 @@ async def get_blogger(blogger_id: int) -> Optional[Blogger]:
                 avg_views=row['avg_views'],
                 avg_likes=row['avg_likes'],
                 engagement_rate=row['engagement_rate'],
+                stories_reach_min=row['stories_reach_min'] if 'stories_reach_min' in row.keys() else None,
+                stories_reach_max=row['stories_reach_max'] if 'stories_reach_max' in row.keys() else None,
+                reels_reach_min=row['reels_reach_min'] if 'reels_reach_min' in row.keys() else None,
+                reels_reach_max=row['reels_reach_max'] if 'reels_reach_max' in row.keys() else None,
                 stats_images=json.loads(row['stats_images']) if row['stats_images'] else [],
                 description=row['description'],
                 created_at=datetime.fromisoformat(row['created_at']) if row['created_at'] else datetime.now(),
@@ -734,6 +768,10 @@ async def get_user_bloggers(seller_id: int) -> List[Blogger]:
                 avg_views=row['avg_views'],
                 avg_likes=row['avg_likes'],
                 engagement_rate=row['engagement_rate'],
+                stories_reach_min=row['stories_reach_min'] if 'stories_reach_min' in row.keys() else None,
+                stories_reach_max=row['stories_reach_max'] if 'stories_reach_max' in row.keys() else None,
+                reels_reach_min=row['reels_reach_min'] if 'reels_reach_min' in row.keys() else None,
+                reels_reach_max=row['reels_reach_max'] if 'reels_reach_max' in row.keys() else None,
                 stats_images=json.loads(row['stats_images']) if row['stats_images'] else [],
                 description=row['description'],
                 created_at=datetime.fromisoformat(row['created_at']) if row['created_at'] else datetime.now(),
@@ -880,6 +918,10 @@ async def search_bloggers(platforms: List[str] = None, categories: List[str] = N
                     avg_views=row['avg_views'],
                     avg_likes=row['avg_likes'],
                     engagement_rate=row['engagement_rate'],
+                    stories_reach_min=row['stories_reach_min'] if 'stories_reach_min' in row.keys() else None,
+                    stories_reach_max=row['stories_reach_max'] if 'stories_reach_max' in row.keys() else None,
+                    reels_reach_min=row['reels_reach_min'] if 'reels_reach_min' in row.keys() else None,
+                    reels_reach_max=row['reels_reach_max'] if 'reels_reach_max' in row.keys() else None,
                     stats_images=json.loads(row['stats_images']) if row['stats_images'] else [],
                     description=row['description'],
                     created_at=datetime.fromisoformat(row['created_at']),

--- a/database/models.py
+++ b/database/models.py
@@ -149,9 +149,17 @@ class Blogger:
     
     # Статистика (будет разной для разных платформ)
     subscribers_count: Optional[int] = None
-    avg_views: Optional[int] = None  # Средние просмотры
+    avg_views: Optional[int] = None  # Средние охваты (устаревшее поле, оставлено для совместимости)
     avg_likes: Optional[int] = None  # Средние лайки
     engagement_rate: Optional[float] = None  # Процент вовлеченности
+    
+    # Охваты сторис (вилка)
+    stories_reach_min: Optional[int] = None  # Минимальный охват сторис
+    stories_reach_max: Optional[int] = None  # Максимальный охват сторис
+    
+    # Охваты рилс (вилка)
+    reels_reach_min: Optional[int] = None  # Минимальный охват рилс
+    reels_reach_max: Optional[int] = None  # Максимальный охват рилс
 
     # Ссылки на изображения со статистикой
     stats_images: List[str] = field(default_factory=list)

--- a/handlers/buyer.py
+++ b/handlers/buyer.py
@@ -512,8 +512,10 @@ async def handle_blogger_selection(callback: CallbackQuery, state: FSMContext):
     
     if blogger.subscribers_count:
         info_text += f"📊 <b>Подписчиков:</b> {blogger.subscribers_count:,}\n"
-    if blogger.avg_views:
-        info_text += f"👁️ <b>Средние просмотры:</b> {blogger.avg_views:,}\n"
+    if blogger.stories_reach_min and blogger.stories_reach_max:
+        info_text += f"👁️ <b>Охват сторис:</b> {blogger.stories_reach_min:,} - {blogger.stories_reach_max:,}\n"
+    if blogger.reels_reach_min and blogger.reels_reach_max:
+        info_text += f"🎬 <b>Охват рилс:</b> {blogger.reels_reach_min:,} - {blogger.reels_reach_max:,}\n"
     if blogger.avg_likes:
         info_text += f"❤️ <b>Средние лайки:</b> {blogger.avg_likes:,}\n"
     if blogger.engagement_rate:

--- a/handlers/seller.py
+++ b/handlers/seller.py
@@ -774,16 +774,17 @@ async def handle_statistics(message: Message, state: FSMContext):
     await state.update_data(subscribers_count=subscribers)
     
     await message.answer(
-        f"📊 Укажите средние просмотры:\n\n"
-        f"Уже указано: Подписчики: {subscribers}",
+        f"📊 Укажите минимальный охват сторис:\n\n"
+        f"Уже указано: Подписчики: {subscribers}\n\n"
+        f"💡 <i>Введите минимальное количество охватов в сторис</i>",
         parse_mode="HTML"
     )
-    await state.set_state(SellerStates.waiting_for_avg_views)
+    await state.set_state(SellerStates.waiting_for_stories_reach_min)
 
 
-@router.message(SellerStates.waiting_for_avg_views)
-async def handle_avg_views(message: Message, state: FSMContext):
-    """Обработка ввода средних просмотров"""
+@router.message(SellerStates.waiting_for_stories_reach_min)
+async def handle_stories_reach_min(message: Message, state: FSMContext):
+    """Обработка ввода минимального охвата сторис"""
     input_text = message.text.strip()
     
     try:
@@ -793,13 +794,13 @@ async def handle_avg_views(message: Message, state: FSMContext):
         if not clean_input:
             raise ValueError("No digits found")
             
-        avg_views = int(clean_input)
+        stories_reach_min = int(clean_input)
         
-        if avg_views < 0:
-            raise ValueError("Negative views")
+        if stories_reach_min < 0:
+            raise ValueError("Negative reach")
             
     except ValueError as e:
-        logger.error(f"Ошибка валидации просмотров: {e}, ввод: '{input_text}'")
+        logger.error(f"Ошибка валидации охвата сторис: {e}, ввод: '{input_text}'")
         await message.answer(
             "❌ <b>Неверный формат</b>\n\n"
             "Введите целое положительное число.\n"
@@ -809,14 +810,172 @@ async def handle_avg_views(message: Message, state: FSMContext):
         )
         return
     
-    await state.update_data(avg_views=avg_views)
+    await state.update_data(stories_reach_min=stories_reach_min)
+    
+    await message.answer(
+        f"📊 Укажите максимальный охват сторис:\n\n"
+        f"Уже указано: Минимальный охват сторис: {stories_reach_min}\n\n"
+        f"💡 <i>Введите максимальное количество охватов в сторис</i>",
+        parse_mode="HTML"
+    )
+    await state.set_state(SellerStates.waiting_for_stories_reach_max)
+
+
+@router.message(SellerStates.waiting_for_stories_reach_max)
+async def handle_stories_reach_max(message: Message, state: FSMContext):
+    """Обработка ввода максимального охвата сторис"""
+    input_text = message.text.strip()
+    data = await state.get_data()
+    stories_reach_min = data.get('stories_reach_min', 0)
+    
+    try:
+        # Убираем возможные пробелы и нечисловые символы
+        clean_input = ''.join(filter(str.isdigit, input_text))
+        
+        if not clean_input:
+            raise ValueError("No digits found")
+            
+        stories_reach_max = int(clean_input)
+        
+        if stories_reach_max < 0:
+            raise ValueError("Negative reach")
+            
+        if stories_reach_max < stories_reach_min:
+            await message.answer(
+                f"❌ <b>Ошибка</b>\n\n"
+                f"Максимальный охват ({stories_reach_max}) не может быть меньше минимального ({stories_reach_min}).\n"
+                f"Попробуйте еще раз:",
+                parse_mode="HTML"
+            )
+            return
+            
+    except ValueError as e:
+        logger.error(f"Ошибка валидации охвата сторис: {e}, ввод: '{input_text}'")
+        await message.answer(
+            "❌ <b>Неверный формат</b>\n\n"
+            "Введите целое положительное число.\n"
+            f"Ваш ввод: '{input_text}'\n"
+            "Попробуйте еще раз:",
+            parse_mode="HTML"
+        )
+        return
+    
+    await state.update_data(stories_reach_max=stories_reach_max)
+    
+    await message.answer(
+        f"📊 Укажите минимальный охват рилс:\n\n"
+        f"Уже указано:\n"
+        f"• Охват сторис: {stories_reach_min} - {stories_reach_max}\n\n"
+        f"💡 <i>Введите минимальное количество охватов в рилс</i>",
+        parse_mode="HTML"
+    )
+    await state.set_state(SellerStates.waiting_for_reels_reach_min)
+
+
+@router.message(SellerStates.waiting_for_reels_reach_min)
+async def handle_reels_reach_min(message: Message, state: FSMContext):
+    """Обработка ввода минимального охвата рилс"""
+    input_text = message.text.strip()
+    
+    try:
+        # Убираем возможные пробелы и нечисловые символы
+        clean_input = ''.join(filter(str.isdigit, input_text))
+        
+        if not clean_input:
+            raise ValueError("No digits found")
+            
+        reels_reach_min = int(clean_input)
+        
+        if reels_reach_min < 0:
+            raise ValueError("Negative reach")
+            
+    except ValueError as e:
+        logger.error(f"Ошибка валидации охвата рилс: {e}, ввод: '{input_text}'")
+        await message.answer(
+            "❌ <b>Неверный формат</b>\n\n"
+            "Введите целое положительное число.\n"
+            f"Ваш ввод: '{input_text}'\n"
+            "Попробуйте еще раз:",
+            parse_mode="HTML"
+        )
+        return
+    
+    await state.update_data(reels_reach_min=reels_reach_min)
+    
+    await message.answer(
+        f"📊 Укажите максимальный охват рилс:\n\n"
+        f"Уже указано: Минимальный охват рилс: {reels_reach_min}\n\n"
+        f"💡 <i>Введите максимальное количество охватов в рилс</i>",
+        parse_mode="HTML"
+    )
+    await state.set_state(SellerStates.waiting_for_reels_reach_max)
+
+
+@router.message(SellerStates.waiting_for_reels_reach_max)
+async def handle_reels_reach_max(message: Message, state: FSMContext):
+    """Обработка ввода максимального охвата рилс"""
+    input_text = message.text.strip()
+    data = await state.get_data()
+    reels_reach_min = data.get('reels_reach_min', 0)
+    
+    try:
+        # Убираем возможные пробелы и нечисловые символы
+        clean_input = ''.join(filter(str.isdigit, input_text))
+        
+        if not clean_input:
+            raise ValueError("No digits found")
+            
+        reels_reach_max = int(clean_input)
+        
+        if reels_reach_max < 0:
+            raise ValueError("Negative reach")
+            
+        if reels_reach_max < reels_reach_min:
+            await message.answer(
+                f"❌ <b>Ошибка</b>\n\n"
+                f"Максимальный охват ({reels_reach_max}) не может быть меньше минимального ({reels_reach_min}).\n"
+                f"Попробуйте еще раз:",
+                parse_mode="HTML"
+            )
+            return
+            
+    except ValueError as e:
+        logger.error(f"Ошибка валидации охвата рилс: {e}, ввод: '{input_text}'")
+        await message.answer(
+            "❌ <b>Неверный формат</b>\n\n"
+            "Введите целое положительное число.\n"
+            f"Ваш ввод: '{input_text}'\n"
+            "Попробуйте еще раз:",
+            parse_mode="HTML"
+        )
+        return
+    
+    await state.update_data(reels_reach_max=reels_reach_max)
+    
+    data = await state.get_data()
+    stories_reach_min = data.get('stories_reach_min')
+    stories_reach_max = data.get('stories_reach_max')
     
     await message.answer(
         f"📊 Укажите средние лайки:\n\n"
-        f"Уже указано: Просмотры: {avg_views}",
+        f"Уже указано:\n"
+        f"• Охват сторис: {stories_reach_min} - {stories_reach_max}\n"
+        f"• Охват рилс: {reels_reach_min} - {reels_reach_max}",
         parse_mode="HTML"
     )
     await state.set_state(SellerStates.waiting_for_avg_likes)
+
+
+# Обработчик для обратной совместимости
+@router.message(SellerStates.waiting_for_avg_views)
+async def handle_avg_views_legacy(message: Message, state: FSMContext):
+    """Обработчик для обратной совместимости - перенаправляет на новый процесс"""
+    await message.answer(
+        f"📊 Укажите минимальный охват сторис:\n\n"
+        f"💡 <i>Введите минимальное количество охватов в сторис</i>",
+        parse_mode="HTML"
+    )
+    await state.set_state(SellerStates.waiting_for_stories_reach_min)
 
 
 @router.message(SellerStates.waiting_for_avg_likes)
@@ -966,6 +1125,10 @@ async def handle_blogger_description(message: Message, state: FSMContext):
             official_payment_possible=data.get('official_payment_possible', False),
             subscribers_count=data.get('subscribers_count'),
             avg_views=data.get('avg_views'),
+            stories_reach_min=data.get('stories_reach_min'),
+            stories_reach_max=data.get('stories_reach_max'),
+            reels_reach_min=data.get('reels_reach_min'),
+            reels_reach_max=data.get('reels_reach_max'),
             avg_likes=data.get('avg_likes'),
             engagement_rate=data.get('engagement_rate'),
             description=description
@@ -1042,8 +1205,10 @@ async def handle_blogger_selection(callback: CallbackQuery, state: FSMContext):
         
         if blogger.subscribers_count:
             info_text += f"📊 <b>Подписчиков:</b> {blogger.subscribers_count:,}\n"
-        if blogger.avg_views:
-            info_text += f"👁️ <b>Средние просмотры:</b> {blogger.avg_views:,}\n"
+        if blogger.stories_reach_min and blogger.stories_reach_max:
+            info_text += f"👁️ <b>Охват сторис:</b> {blogger.stories_reach_min:,} - {blogger.stories_reach_max:,}\n"
+        if blogger.reels_reach_min and blogger.reels_reach_max:
+            info_text += f"🎬 <b>Охват рилс:</b> {blogger.reels_reach_min:,} - {blogger.reels_reach_max:,}\n"
         if blogger.avg_likes:
             info_text += f"❤️ <b>Средние лайки:</b> {blogger.avg_likes:,}\n"
         if blogger.engagement_rate:


### PR DESCRIPTION
Replace 'views' with 'reach' and add min/max reach for stories and reels to improve metric accuracy.

The user requested to change the terminology from "просмотры" (views) to "охваты" (reach) and to introduce a range (minimum and maximum) for "охваты" in both stories and reels, as opposed to a single average value. This PR implements these changes, updates the database schema, data models, and all relevant UI/logic flows, while maintaining backward compatibility for the old `avg_views` field.

---

[Open in Web](https://cursor.com/agents?id=bc-71b04499-7507-40fa-8e2d-100cdc2ea408) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-71b04499-7507-40fa-8e2d-100cdc2ea408) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)