### PR TITLE
Update reach terminology and implement ranges

### DIFF
--- a/bot/states.py
+++ b/bot/states.py
@@ -41,6 +41,10 @@ class SellerStates(StatesGroup):
     waiting_for_statistics = State()  # Загрузка статистики
     waiting_for_subscribers_count = State()  # Количество подписчиков
     waiting_for_avg_views = State()  # Средние просмотры
+    # Новые состояния для ввода охватов
+    waiting_for_stories_reach_max = State()  # Максимальный охват сторис
+    waiting_for_reels_reach_min = State()    # Минимальный охват рилс
+    waiting_for_reels_reach_max = State()    # Максимальный охват рилс
     waiting_for_avg_likes = State()  # Средние лайки
     waiting_for_engagement_rate = State()  # Процент вовлеченности
     

--- a/database/database.py
+++ b/database/database.py
@@ -82,6 +82,10 @@ async def init_db():
                 
                 -- Статистика
                 subscribers_count INTEGER,
+                stories_reach_min INTEGER,
+                stories_reach_max INTEGER,
+                reels_reach_min INTEGER,
+                reels_reach_max INTEGER,
                 avg_views INTEGER,
                 avg_likes INTEGER,
                 engagement_rate REAL,
@@ -335,6 +339,23 @@ async def init_db():
                 await db.execute("ALTER TABLE bloggers ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
                 logger.info("Added updated_at column to bloggers table")
                 
+            # Добавляем новые колонки охватов, если их нет (вилка охватов для сторис и рилс)
+            if 'stories_reach_min' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN stories_reach_min INTEGER")
+                logger.info("Added stories_reach_min column to bloggers table")
+
+            if 'stories_reach_max' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN stories_reach_max INTEGER")
+                logger.info("Added stories_reach_max column to bloggers table")
+
+            if 'reels_reach_min' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN reels_reach_min INTEGER")
+                logger.info("Added reels_reach_min column to bloggers table")
+
+            if 'reels_reach_max' not in columns:
+                await db.execute("ALTER TABLE bloggers ADD COLUMN reels_reach_max INTEGER")
+                logger.info("Added reels_reach_max column to bloggers table")
+                
         except Exception as e:
             logger.error(f"Error during migration: {e}")
         
@@ -575,11 +596,11 @@ async def create_blogger(
                 female_percent, male_percent,
                 price_stories, price_post, price_video,
                 has_reviews, is_registered_rkn, official_payment_possible,
-                subscribers_count, avg_views, avg_likes, engagement_rate,
+                subscribers_count, stories_reach_min, stories_reach_max, reels_reach_min, reels_reach_max, avg_views, avg_likes, engagement_rate,
                 stats_images,
                 description
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
             (
                 seller_id,
@@ -600,6 +621,10 @@ async def create_blogger(
                 kwargs.get("is_registered_rkn", False),
                 kwargs.get("official_payment_possible", False),
                 kwargs.get("subscribers_count"),
+                kwargs.get("stories_reach_min"),
+                kwargs.get("stories_reach_max"),
+                kwargs.get("reels_reach_min"),
+                kwargs.get("reels_reach_max"),
                 kwargs.get("avg_views"),
                 kwargs.get("avg_likes"),
                 kwargs.get("engagement_rate"),
@@ -666,6 +691,10 @@ async def get_blogger(blogger_id: int) -> Optional[Blogger]:
                 is_registered_rkn=bool(row['is_registered_rkn']),
                 official_payment_possible=bool(row['official_payment_possible']),
                 subscribers_count=row['subscribers_count'],
+                stories_reach_min=row['stories_reach_min'],
+                stories_reach_max=row['stories_reach_max'],
+                reels_reach_min=row['reels_reach_min'],
+                reels_reach_max=row['reels_reach_max'],
                 avg_views=row['avg_views'],
                 avg_likes=row['avg_likes'],
                 engagement_rate=row['engagement_rate'],
@@ -731,6 +760,10 @@ async def get_user_bloggers(seller_id: int) -> List[Blogger]:
                 is_registered_rkn=bool(row['is_registered_rkn']),
                 official_payment_possible=bool(row['official_payment_possible']),
                 subscribers_count=row['subscribers_count'],
+                stories_reach_min=row['stories_reach_min'],
+                stories_reach_max=row['stories_reach_max'],
+                reels_reach_min=row['reels_reach_min'],
+                reels_reach_max=row['reels_reach_max'],
                 avg_views=row['avg_views'],
                 avg_likes=row['avg_likes'],
                 engagement_rate=row['engagement_rate'],
@@ -921,7 +954,8 @@ async def update_blogger(blogger_id: int, seller_id: int, **kwargs) -> bool:
     allowed_fields = [
         'name', 'url', 'platforms', 'categories',
         'price_stories', 'price_post', 'price_video',
-        'has_reviews', 'description', 'stats_images'
+        'has_reviews', 'description', 'stats_images',
+        'stories_reach_min', 'stories_reach_max', 'reels_reach_min', 'reels_reach_max'
     ]
     
     # Фильтруем только разрешенные поля

--- a/database/models.py
+++ b/database/models.py
@@ -149,6 +149,11 @@ class Blogger:
     
     # Статистика (будет разной для разных платформ)
     subscribers_count: Optional[int] = None
+    # Охват (вилка)
+    stories_reach_min: Optional[int] = None  # Минимальный охват сторис
+    stories_reach_max: Optional[int] = None  # Максимальный охват сторис
+    reels_reach_min: Optional[int] = None    # Минимальный охват рилс
+    reels_reach_max: Optional[int] = None    # Максимальный охват рилс
     avg_views: Optional[int] = None  # Средние просмотры
     avg_likes: Optional[int] = None  # Средние лайки
     engagement_rate: Optional[float] = None  # Процент вовлеченности

--- a/handlers/buyer.py
+++ b/handlers/buyer.py
@@ -512,8 +512,10 @@ async def handle_blogger_selection(callback: CallbackQuery, state: FSMContext):
     
     if blogger.subscribers_count:
         info_text += f"📊 <b>Подписчиков:</b> {blogger.subscribers_count:,}\n"
-    if blogger.avg_views:
-        info_text += f"👁️ <b>Средние просмотры:</b> {blogger.avg_views:,}\n"
+    if blogger.stories_reach_min and blogger.stories_reach_max:
+        info_text += f"👁️ <b>Охват сторис:</b> {blogger.stories_reach_min:,} - {blogger.stories_reach_max:,}\n"
+    if blogger.reels_reach_min and blogger.reels_reach_max:
+        info_text += f"🎞️ <b>Охват рилс:</b> {blogger.reels_reach_min:,} - {blogger.reels_reach_max:,}\n"
     if blogger.avg_likes:
         info_text += f"❤️ <b>Средние лайки:</b> {blogger.avg_likes:,}\n"
     if blogger.engagement_rate:

--- a/handlers/seller.py
+++ b/handlers/seller.py
@@ -774,7 +774,7 @@ async def handle_statistics(message: Message, state: FSMContext):
     await state.update_data(subscribers_count=subscribers)
     
     await message.answer(
-        f"📊 Укажите средние просмотры:\n\n"
+        f"📊 Укажите <b>минимальный охват сторис</b>:\n\n"
         f"Уже указано: Подписчики: {subscribers}",
         parse_mode="HTML"
     )
@@ -783,7 +783,7 @@ async def handle_statistics(message: Message, state: FSMContext):
 
 @router.message(SellerStates.waiting_for_avg_views)
 async def handle_avg_views(message: Message, state: FSMContext):
-    """Обработка ввода средних просмотров"""
+    """Обработка ввода минимального охвата сторис"""
     input_text = message.text.strip()
     
     try:
@@ -793,10 +793,10 @@ async def handle_avg_views(message: Message, state: FSMContext):
         if not clean_input:
             raise ValueError("No digits found")
             
-        avg_views = int(clean_input)
-        
-        if avg_views < 0:
-            raise ValueError("Negative views")
+        stories_min = int(clean_input)
+
+        if stories_min < 0:
+            raise ValueError("Negative reach")
             
     except ValueError as e:
         logger.error(f"Ошибка валидации просмотров: {e}, ввод: '{input_text}'")
@@ -809,13 +809,132 @@ async def handle_avg_views(message: Message, state: FSMContext):
         )
         return
     
-    await state.update_data(avg_views=avg_views)
+    await state.update_data(stories_reach_min=stories_min)
     
     await message.answer(
-        f"📊 Укажите средние лайки:\n\n"
-        f"Уже указано: Просмотры: {avg_views}",
+        f"📊 Укажите <b>максимальный охват сторис</b>:\n\n"
+        f"Уже указано: Мин. охват сторис: {stories_min}",
         parse_mode="HTML"
     )
+    await state.set_state(SellerStates.waiting_for_stories_reach_max)
+
+
+@router.message(SellerStates.waiting_for_stories_reach_max)
+async def handle_stories_reach_max(message: Message, state: FSMContext):
+    """Обработка ввода максимального охвата сторис"""
+    input_text = message.text.strip()
+    
+    try:
+        # Убираем возможные пробелы и нечисловые символы
+        clean_input = ''.join(filter(str.isdigit, input_text))
+        
+        if not clean_input:
+            raise ValueError("No digits found")
+            
+        stories_max = int(clean_input)
+
+        if stories_max < 0:
+            raise ValueError("Negative reach")
+            
+    except ValueError as e:
+        logger.error(f"Ошибка валидации просмотров: {e}, ввод: '{input_text}'")
+        await message.answer(
+            "❌ <b>Неверный формат</b>\n\n"
+            "Введите целое положительное число.\n"
+            f"Ваш ввод: '{input_text}'\n"
+            "Попробуйте еще раз:",
+            parse_mode="HTML"
+        )
+        return
+    
+    await state.update_data(stories_reach_max=stories_max)
+    
+    await message.answer(
+        f"📊 Укажите <b>минимальный охват рилс</b>:",
+        parse_mode="HTML"
+    )
+    await state.set_state(SellerStates.waiting_for_reels_reach_min)
+
+
+@router.message(SellerStates.waiting_for_reels_reach_min)
+async def handle_reels_reach_min(message: Message, state: FSMContext):
+    """Обработка ввода минимального охвата рилс"""
+    input_text = message.text.strip()
+    
+    try:
+        # Убираем возможные пробелы и нечисловые символы
+        clean_input = ''.join(filter(str.isdigit, input_text))
+        
+        if not clean_input:
+            raise ValueError("No digits found")
+            
+        reels_min = int(clean_input)
+
+        if reels_min < 0:
+            raise ValueError("Negative reach")
+            
+    except ValueError as e:
+        logger.error(f"Ошибка валидации просмотров: {e}, ввод: '{input_text}'")
+        await message.answer(
+            "❌ <b>Неверный формат</b>\n\n"
+            "Введите целое положительное число.\n"
+            f"Ваш ввод: '{input_text}'\n"
+            "Попробуйте еще раз:",
+            parse_mode="HTML"
+        )
+        return
+    
+    await state.update_data(reels_reach_min=reels_min)
+    
+    await message.answer(
+        f"📊 Укажите <b>максимальный охват рилс</b>:\n\n"
+        f"Уже указано: Мин. охват рилс: {reels_min}",
+        parse_mode="HTML"
+    )
+    await state.set_state(SellerStates.waiting_for_reels_reach_max)
+
+
+@router.message(SellerStates.waiting_for_reels_reach_max)
+async def handle_reels_reach_max(message: Message, state: FSMContext):
+    """Обработка ввода максимального охвата рилс"""
+    input_text = message.text.strip()
+    
+    try:
+        # Убираем возможные пробелы и нечисловые символы
+        clean_input = ''.join(filter(str.isdigit, input_text))
+        
+        if not clean_input:
+            raise ValueError("No digits found")
+            
+        reels_max = int(clean_input)
+
+        if reels_max < 0:
+            raise ValueError("Negative reach")
+            
+    except ValueError as e:
+        logger.error(f"Ошибка валидации просмотров: {e}, ввод: '{input_text}'")
+        await message.answer(
+            "❌ <b>Неверный формат</b>\n\n"
+            "Введите целое положительное число.\n"
+            f"Ваш ввод: '{input_text}'\n"
+            "Попробуйте еще раз:",
+            parse_mode="HTML"
+        )
+        return
+    
+    await state.update_data(reels_reach_max=reels_max)
+
+    data = await state.get_data()
+    stories_min = data.get('stories_reach_min')
+    stories_max = data.get('stories_reach_max')
+    reels_min = data.get('reels_reach_min')
+    
+    await message.answer(
+         f"📊 Укажите средние лайки:\n\n"
+         f"Уже указано: Мин. охват сторис: {stories_min}, Макс. охват сторис: {stories_max}\n"
+         f"Мин. охват рилс: {reels_min}, Макс. охват рилс: {reels_max}",
+         parse_mode="HTML"
+     )
     await state.set_state(SellerStates.waiting_for_avg_likes)
 
 
@@ -965,7 +1084,10 @@ async def handle_blogger_description(message: Message, state: FSMContext):
             is_registered_rkn=data.get('is_registered_rkn', False),
             official_payment_possible=data.get('official_payment_possible', False),
             subscribers_count=data.get('subscribers_count'),
-            avg_views=data.get('avg_views'),
+            stories_reach_min=data.get('stories_reach_min'),
+            stories_reach_max=data.get('stories_reach_max'),
+            reels_reach_min=data.get('reels_reach_min'),
+            reels_reach_max=data.get('reels_reach_max'),
             avg_likes=data.get('avg_likes'),
             engagement_rate=data.get('engagement_rate'),
             description=description
@@ -1042,8 +1164,10 @@ async def handle_blogger_selection(callback: CallbackQuery, state: FSMContext):
         
         if blogger.subscribers_count:
             info_text += f"📊 <b>Подписчиков:</b> {blogger.subscribers_count:,}\n"
-        if blogger.avg_views:
-            info_text += f"👁️ <b>Средние просмотры:</b> {blogger.avg_views:,}\n"
+        if blogger.stories_reach_min and blogger.stories_reach_max:
+            info_text += f"👁️ <b>Охват сторис:</b> {blogger.stories_reach_min:,} - {blogger.stories_reach_max:,}\n"
+        if blogger.reels_reach_min and blogger.reels_reach_max:
+            info_text += f"🎞️ <b>Охват рилс:</b> {blogger.reels_reach_min:,} - {blogger.reels_reach_max:,}\n"
         if blogger.avg_likes:
             info_text += f"❤️ <b>Средние лайки:</b> {blogger.avg_likes:,}\n"
         if blogger.engagement_rate:


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replaced "average views" with "reach ranges" (min/max for stories and reels) across the application as per user request.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user explicitly requested to change the metric from "views" to "reach" and to capture a range (minimum and maximum) for both stories and reels, impacting data storage, input flow, and display.

---

[Open in Web](https://cursor.com/agents?id=bc-e09da2a3-95d3-40f2-b4c7-9ae1a97c1ad7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e09da2a3-95d3-40f2-b4c7-9ae1a97c1ad7) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)