### PR TITLE
Add link to view statistics screenshots

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -452,6 +452,45 @@ def get_edit_blogger_keyboard(blogger_id: int) -> InlineKeyboardMarkup:
     ])
 
 
+def get_blogger_management_keyboard(blogger_id: int) -> InlineKeyboardMarkup:
+    """Клавиатура управления блогером в списке"""
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [
+            InlineKeyboardButton(text="✏️ Редактировать", callback_data=f"edit_blogger_{blogger_id}")
+        ],
+        [
+            InlineKeyboardButton(text="📊 Посмотреть фото статистики", callback_data=f"view_stats_photos_{blogger_id}")
+        ],
+        [
+            InlineKeyboardButton(text="🗑 Удалить", callback_data=f"delete_blogger_{blogger_id}")
+        ]
+    ])
+
+
+def get_blogger_management_keyboard_with_stats(blogger_id: int, has_stats_photos: bool) -> InlineKeyboardMarkup:
+    """Клавиатура управления блогером в списке с учетом наличия фото статистики"""
+    keyboard = [
+        [
+            InlineKeyboardButton(text="✏️ Редактировать", callback_data=f"edit_blogger_{blogger_id}")
+        ]
+    ]
+    
+    if has_stats_photos:
+        keyboard.append([
+            InlineKeyboardButton(text="📊 Посмотреть фото статистики", callback_data=f"view_stats_photos_{blogger_id}")
+        ])
+    else:
+        keyboard.append([
+            InlineKeyboardButton(text="📊 Посмотреть скриншоты статистики", callback_data=f"view_stats_photos_{blogger_id}")
+        ])
+    
+    keyboard.append([
+        InlineKeyboardButton(text="🗑 Удалить", callback_data=f"delete_blogger_{blogger_id}")
+    ])
+    
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
 def get_confirmation_keyboard() -> InlineKeyboardMarkup:
     """Клавиатура подтверждения действия"""
     return InlineKeyboardMarkup(inline_keyboard=[

--- a/handlers/seller.py
+++ b/handlers/seller.py
@@ -22,7 +22,9 @@ from bot.keyboards import (
     get_blogger_edit_field_keyboard,
     get_blogger_success_keyboard_enhanced,
     get_delete_confirmation_keyboard,
-    get_edit_blogger_keyboard
+    get_edit_blogger_keyboard,
+    get_blogger_management_keyboard,
+    get_blogger_management_keyboard_with_stats
 )
 from bot.states import SellerStates
 from typing import Union
@@ -949,9 +951,22 @@ async def show_my_bloggers(message: Message, state: FSMContext):
         info_text = f"📝 <b>Блогер #{blogger.id}</b>\n\n"
         info_text += format_full_blogger_info(blogger)
         
+        # Проверяем наличие фото статистики
+        has_stats_photos = False
+        if blogger.stats_images:
+            if isinstance(blogger.stats_images, str):
+                try:
+                    import json
+                    stats_images_list = json.loads(blogger.stats_images)
+                    has_stats_photos = stats_images_list and len(stats_images_list) > 0
+                except:
+                    has_stats_photos = False
+            else:
+                has_stats_photos = len(blogger.stats_images) > 0
+        
         await message.answer(
             info_text,
-            reply_markup=get_blogger_management_keyboard(blogger.id),
+            reply_markup=get_blogger_management_keyboard_with_stats(blogger.id, has_stats_photos),
             parse_mode="HTML"
         )
 
@@ -1444,7 +1459,8 @@ async def handle_view_stats_photos(callback: CallbackQuery):
     if not stats_images or len(stats_images) == 0:
         await callback.message.answer(
             "📊 <b>Статистика профиля</b>\n\n"
-            "У этого блогера нет загруженных фото статистики.",
+            "У этого блогера нет загруженных фото статистики.\n\n"
+            "💡 <i>Для добавления фото статистики используйте кнопку '✏️ Редактировать' → '📊 Фото статистики'</i>",
             parse_mode="HTML"
         )
         return


### PR DESCRIPTION
Add a conditional "View Statistics" button to blogger management, showing "screenshots" when no photos are uploaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-da3511d3-54e0-4030-91fc-e81335eb848f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da3511d3-54e0-4030-91fc-e81335eb848f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>